### PR TITLE
Improve cert send

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Today we use a webinterface for user input that lives at
 provides us with an id and e-mail and generates a certificate request in the
 database. After the generation of the request an admin has to execute
 `python3 manage.py requests process` on the server to create the certificate and send it to the
-user. To send an already existing certificate again use `python3 manage.py certificates send --id=ID [--email=EMAIL]`.
+user. To send an already existing certificate again use `python3 manage.py certificates send [-e EMAIL] ID`.
 
 See also: `python3 manage.py requests --help` and: `python3 manage.py certificates --help`
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ Today we use a webinterface for user input that lives at
 provides us with an id and e-mail and generates a certificate request in the
 database. After the generation of the request an admin has to execute
 `python3 manage.py requests process` on the server to create the certificate and send it to the
-user. To send an already existing certificate again use `python3 manage.py certificates send`.
+user. To send an already existing certificate again use `python3 manage.py certificates send --id=ID [--email=EMAIL]`.
 
-See also:
-`python3 manage.py requests --help`
-`python3 manage.py certificates --help`
+See also: `python3 manage.py requests --help` and: `python3 manage.py certificates --help`
 
 ## Development
 

--- a/manage.py
+++ b/manage.py
@@ -80,14 +80,10 @@ def send(id, email=None):
     "Send existing certificate again"
     for request in Request.query.filter(Request.generation_date != None).all():  # noqa
         if request.id == id:
-            print("ID found. Try to mail certificate again...")
+            print("ID found.")
             if email is None:
                 email = request.email
-            try:
-                mail_certificate(id, email)
-                print("OK")
-            except:
-                print("Sorry, something went wrong.")
+            mail_certificate(id, email)
             return
 
 

--- a/manage.py
+++ b/manage.py
@@ -87,14 +87,15 @@ def show():
 @certificates_subcommands.command
 def send(id, email=None):
     "Send existing certificate again"
-    for request in Request.query.filter(Request.generation_date != None).all():  # noqa
-        if request.id == id:
-            print("ID found.")
-            if email is None:
-                email = request.email
-                print("Set EMAIL to emailaddress used for former request.")
-            mail_certificate(id, email)
-            return
+    request = Request.query.filter(Request.id == id).first()
+    if request is None:
+        print("Sorry. ID not found.")
+        return
+    print("ID found. Trying to send email...")
+    if email is None:
+        email = request.email
+        print("Set EMAIL to emailaddress used for former request.")
+    mail_certificate(id, email)
 
 
 @certificates_subcommands.command

--- a/manage.py
+++ b/manage.py
@@ -34,7 +34,7 @@ def mail_certificate(id, email):
                 recipients=[email]
                 )
         msg.body = render_template('mail.txt')
-        print("Looking for archive to attach...")
+        print("Looking for archive with certificate to attach...")
         try:
             certificate_path = "{}/freifunk_{}.tgz".format(
                     app.config['DIRECTORY_CLIENTS'],
@@ -47,14 +47,14 @@ def mail_certificate(id, email):
                         fp.read()
                         )
         except:
-            print("Sorry, that didn't work.")
+            print("Sorry, couldn't find archive file in expected directory.")
             return
         print("Send the email...")
         try:
             mail.send(msg)
             print("OK.")
         except:
-            print("Sorry, that didn't work.")
+            print("Sorry, couldn't sent Email.")
 
 
 @requests_subcommands.command
@@ -68,6 +68,7 @@ def process():
         if confirm in ['Y', 'y']:
             print('Generating certificate')
             call([app.config['COMMAND_BUILD'], request.id, request.email])
+            print("Ready. Trying to send email...")
             mail_certificate(request.id, request.email)
             request.generation_date = datetime.date.today()
             db.session.commit()

--- a/manage.py
+++ b/manage.py
@@ -83,6 +83,7 @@ def send(id, email=None):
             print("ID found.")
             if email is None:
                 email = request.email
+                print("Set EMAIL to emailaddress used for former request.")
             mail_certificate(id, email)
             return
 

--- a/manage.py
+++ b/manage.py
@@ -75,17 +75,16 @@ def show():
 
 
 @certificates_subcommands.command
-@manager.option('-i', '--id', dest='send_again_id')
-@manager.option('-e', '--email', dest='send_again_mail', default=None)
-def send(send_again_id, send_again_mail):
+@manager.command
+def send(id, email=None):
     "Send existing certificate again"
     for request in Request.query.filter(Request.generation_date != None).all():  # noqa
-        if request.id == send_again_id:
+        if request.id == id:
             print("ID found. Try to mail certificate again...")
-            if send_again_mail is None:
-                send_again_mail = request.email
+            if email is None:
+                email = request.email
             try:
-                mail_certificate(send_again_id, send_again_mail)
+                mail_certificate(id, email)
                 print("OK")
             except:
                 print("Sorry, something went wrong.")

--- a/manage.py
+++ b/manage.py
@@ -75,7 +75,6 @@ def show():
 
 
 @certificates_subcommands.command
-@manager.command
 def send(id, email=None):
     "Send existing certificate again"
     for request in Request.query.filter(Request.generation_date != None).all():  # noqa

--- a/manage.py
+++ b/manage.py
@@ -34,17 +34,27 @@ def mail_certificate(id, email):
                 recipients=[email]
                 )
         msg.body = render_template('mail.txt')
-        certificate_path = "{}/freifunk_{}.tgz".format(
-                app.config['DIRECTORY_CLIENTS'],
-                id
-                )
-        with app.open_resource(certificate_path) as fp:
-            msg.attach(
-                    "freifunk_{}.tgz".format(id),
-                    "application/gzip",
-                    fp.read()
+        print("Looking for archive to attach...")
+        try:
+            certificate_path = "{}/freifunk_{}.tgz".format(
+                    app.config['DIRECTORY_CLIENTS'],
+                    id
                     )
-        mail.send(msg)
+            with app.open_resource(certificate_path) as fp:
+                msg.attach(
+                        "freifunk_{}.tgz".format(id),
+                        "application/gzip",
+                        fp.read()
+                        )
+        except:
+            print("Sorry, that didn't work.")
+            return
+        print("Send the email...")
+        try:
+            mail.send(msg)
+            print("OK.")
+        except:
+            print("Sorry, that didn't work.")
 
 
 @requests_subcommands.command
@@ -56,14 +66,14 @@ def process():
         print("Type y to continue")
         confirm = input('>')
         if confirm in ['Y', 'y']:
-            print('generating certificate')
+            print('Generating certificate')
             call([app.config['COMMAND_BUILD'], request.id, request.email])
             mail_certificate(request.id, request.email)
             request.generation_date = datetime.date.today()
             db.session.commit()
             print()
         else:
-            print('skipping generation \n')
+            print('Skipping generation \n')
 
 
 @requests_subcommands.command

--- a/manage.py
+++ b/manage.py
@@ -75,17 +75,21 @@ def show():
 
 
 @certificates_subcommands.command
-def send():
+@manager.option('-i', '--id', dest='send_again_id')
+@manager.option('-e', '--email', dest='send_again_mail', default=None)
+def send(send_again_id, send_again_mail):
     "Send existing certificate again"
-    print("Which existing certificate do you want to send again? Type the ID")
-    send_again_id = input('>')
-    print("Where should it be sent? Please type the Email")
-    send_again_mail = input('>')
-    try:
-        mail_certificate(send_again_id, send_again_mail)
-        print("OK")
-    except:
-        print("That didn't work.")
+    for request in Request.query.filter(Request.generation_date != None).all():  # noqa
+        if request.id == send_again_id:
+            print("ID found. Try to mail certificate again...")
+            if send_again_mail is None:
+                send_again_mail = request.email
+            try:
+                mail_certificate(send_again_id, send_again_mail)
+                print("OK")
+            except:
+                print("Sorry, something went wrong.")
+            return
 
 
 @certificates_subcommands.command

--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from flask.ext.script import Manager
+from flask.ext.script import Manager, Command, Option
 from flask.ext.migrate import Migrate, MigrateCommand
 from ca import app, db, mail
 


### PR DESCRIPTION
New usage is: python3 manage.py certificates send [-e EMAIL] ID
Send existing certificate of ID to EMAIL.
(Send certificate to emailaddress used for request if EMAIL is not set.)
