### PR TITLE
Hilfetext für den "Anfordern"-Button

### DIFF
--- a/ca/templates/index.html
+++ b/ca/templates/index.html
@@ -27,6 +27,11 @@
         <div class="col-sm-offset-2 col-sm-10">
           <button type="submit" class="btn btn-default">Anfordern</button>
         </div>
+        <span class="help-block italic">
+          Das Ausstellen des Zertifikates kann sich auch bis zu zwei Wochen hinziehen,
+          da das unsere VPN03-Adminstratoren in liebevoller Handarbeit machen.
+          Wenn sie es gemacht haben, bekommst Du eine E-Mail.
+        </span>
       </div>
     </form>
   </div>


### PR DESCRIPTION
Problem: #41 Wir würden gerne wissen, wie lange es dauert, bis die Zertifikate bei uns ankommen.

Lösung: Nach dem Anfordern-Button ist ein Hilfetext, der kurz beschreibt, wie lange es dauert.
