### PR TITLE
Update pyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==0.8.2
+blinker==1.4
 cffi==1.2.1
-cryptography==1.0.1
+cryptography==1.5.2
 Flask==0.10.1
 Flask-Mail==0.9.1
 Flask-Migrate==1.6.0
@@ -13,7 +14,7 @@ Mako==1.0.2
 MarkupSafe==0.23
 pyasn1==0.1.8
 pycparser==2.14
-pyOpenSSL==0.15.1
+pyOpenSSL==16.2.0
 python-editor==0.4
 six==1.9.0
 SQLAlchemy==1.0.8


### PR DESCRIPTION
This updates pyOpenSSL to the latest version. This is so that the
dependency `cryptography` is also updated. This update is necessary for
the installation to work on a recent version of macOS